### PR TITLE
Fix AdvancedLivePortrait node parameter order and syntax error

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -723,7 +723,7 @@ class AdvancedLivePortrait:
         return cmd_list, total_length
 
 
-    def run(self, retargeting_eyes, retargeting_mouth, turn_on, tracking_src_vid, animate_without_vid, command, crop_factor,
+    def run(self, retargeting_eyes, retargeting_mouth, crop_factor, turn_on, tracking_src_vid, animate_without_vid, command,
             src_images=None, driving_images=None, motion_link=None):
         if turn_on == False: return (None,None)
         src_length = 1
@@ -969,7 +969,7 @@ NODE_CLASS_MAPPINGS = {
     "LoadExpData": LoadExpData,
     "SaveExpData": SaveExpData,
     "ExpData": ExpData,
-    "PrintExpData:": PrintExpData,
+    "PrintExpData": PrintExpData,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {


### PR DESCRIPTION
## Problem Description
- AdvancedLivePortrait node missing `tracking_src_vid` and `animate_without_vid` options
- Syntax error in PrintExpData class name

## Changes Made
1. **Fixed parameter order issue**:
   - Adjusted the parameter order in AdvancedLivePortrait class `run` method to match the `INPUT_TYPES` definition
   - This resolves the issue where `tracking_src_vid` and `animate_without_vid` options were not displaying

2. **Fixed syntax error**:
   - Removed extra colon from PrintExpData class name in NODE_CLASS_MAPPINGS

## Technical Details
The issue was caused by a mismatch between the parameter order in the `run` method and the `INPUT_TYPES` definition. ComfyUI requires these to be in exact order for proper parameter mapping.

**Before:**
```python
def run(self, retargeting_eyes, retargeting_mouth, turn_on, tracking_src_vid, animate_without_vid, command, crop_factor, ...)
```

**After:**
```python
def run(self, retargeting_eyes, retargeting_mouth, crop_factor, turn_on, tracking_src_vid, animate_without_vid, command, ...)
```

## Testing
- After the fix, AdvancedLivePortrait node now correctly displays all 7 parameter options
- Including the previously missing `tracking_src_vid` and `animate_without_vid` options
- No breaking changes to existing functionality

## Impact
- This is a bug fix that improves user experience
- Maintains backward compatibility
- No existing workflows will be affected